### PR TITLE
[3396] - Fix failing geocoding.spec.ts

### DIFF
--- a/cypress/integration/find-teacher-training/geocoding.spec.ts
+++ b/cypress/integration/find-teacher-training/geocoding.spec.ts
@@ -18,7 +18,7 @@ describe("Geocoding", () => {
   it("should let user search by location", () => {
     cy.contains("By postcode").click();
     cy.get("#location").type("westmin");
-    cy.contains("Westminster, London, UK").click();
+    cy.contains("Westminster, London").click();
     cy.contains("Continue").click();
     cy.get(".govuk-error-summary").should("not.exist");
     cy.get("h1").should("contain", "Find courses by subject");


### PR DESCRIPTION
### Context
The location autocomplete no longer displays "UK" in each location suggestion - https://github.com/DFE-Digital/find-teacher-training/pull/356

### Changes proposed
- Fixes failing `geocoding.spec.ts`. The spec no longer asserts that the location suggestion has "UK"