### PR TITLE
Update specs to handle the 'cycle ending soon' event

### DIFF
--- a/cypress/integration/find-teacher-training/basic.spec.ts
+++ b/cypress/integration/find-teacher-training/basic.spec.ts
@@ -8,6 +8,7 @@ describe("Basic", () => {
   before(() => {
     cy.clearCookies()
     cy.visit(URL);
+    cy.contains("Find courses with vacancies").click();
     cy.contains("Continue").click();
   });
 

--- a/cypress/integration/find-teacher-training/geocoding.spec.ts
+++ b/cypress/integration/find-teacher-training/geocoding.spec.ts
@@ -8,6 +8,7 @@ describe("Geocoding", () => {
   before(() => {
     cy.clearCookies()
     cy.visit(URL);
+    cy.contains("Find courses with vacancies").click();
     cy.contains("Continue").click();
   });
 


### PR DESCRIPTION
### Context
Specs are failing because Find has activated the ‘cycle ending soon’ page.

### Fix
Specs now click through the ‘cycle ending soon’ page before beginning the search process.
[See related Find fix ](https://github.com/DFE-Digital/find-teacher-training/pull/436)

### Trello
https://trello.com/c/AidwYrAz/2119-fix-broken-find-end-to-end-tests