### PR TITLE
Update link click on 'cycle ending soon' page

### DIFF
--- a/cypress/integration/find-teacher-training/basic.spec.ts
+++ b/cypress/integration/find-teacher-training/basic.spec.ts
@@ -8,7 +8,7 @@ describe("Basic", () => {
   before(() => {
     cy.clearCookies()
     cy.visit(URL);
-    cy.contains("Find courses with vacancies").click();
+    cy.contains("this website is still showing some courses (these may not be available for the 2021 to 2022 academic year)").click();
     cy.contains("Continue").click();
   });
 

--- a/cypress/integration/find-teacher-training/geocoding.spec.ts
+++ b/cypress/integration/find-teacher-training/geocoding.spec.ts
@@ -8,7 +8,7 @@ describe("Geocoding", () => {
   before(() => {
     cy.clearCookies()
     cy.visit(URL);
-    cy.contains("Find courses with vacancies").click();
+    cy.contains("this website is still showing some courses (these may not be available for the 2021 to 2022 academic year)").click();
     cy.contains("Continue").click();
   });
 


### PR DESCRIPTION
## Context

Copy update was made on the 'cycle-ending-soon' page. See https://github.com/DFE-Digital/find-teacher-training/pull/455

### Changes in this PR

As a result of a copy update on the 'cycle-ending-soon' page we need to update the link click in these tests.