### PR TITLE
Fix failing geocoding smoke test

### DIFF
--- a/cypress/integration/find-teacher-training/geocoding.spec.ts
+++ b/cypress/integration/find-teacher-training/geocoding.spec.ts
@@ -34,6 +34,6 @@ describe("Geocoding", () => {
 
   it("should let users view a course", () => {
     cy.get(".app-search-result__course-name:first").click();
-    cy.get("h1").should("contain", "Business");
+    cy.get("h2").should("contain", "Business");
   });
 });


### PR DESCRIPTION
As part of a previous release geocoding smoke test broke silently. This became apparent when merging in cookie banner.
This PR fixes the test by altering the h1 to an h2.