### PR TITLE
Fix geocoder smoke test again

### DIFF
--- a/cypress/integration/find-teacher-training/geocoding.spec.ts
+++ b/cypress/integration/find-teacher-training/geocoding.spec.ts
@@ -33,7 +33,7 @@ describe("Geocoding", () => {
   });
 
   it("should let users view a course", () => {
-    cy.get(".app-search-result__course-name:first").click();
-    cy.get("h2").should("contain", "Business");
+    cy.get(".app-search-result__provider-name:first").click();
+    cy.get("h1").should("contain", "Business");
   });
 });


### PR DESCRIPTION
The previous fix for the failing smoke test was insufficient as it didn't address the issue it just hotwired the test to pass.
This fix makes sure that functionality is covered sufficiently.