### PR TITLE
Cypress isn't clicking the correct link, use whole section instead

### DIFF
--- a/cypress/integration/find-teacher-training/basic.spec.ts
+++ b/cypress/integration/find-teacher-training/basic.spec.ts
@@ -46,7 +46,7 @@ describe("Basic", () => {
   });
 
   it("should let users view a course", () => {
-    cy.get(".app-search-result__course-name:first").click();
+    cy.get(".app-search-result__item-title:first").click();
     cy.get("h1").should("contain", "Business");
   });
 


### PR DESCRIPTION
Cypress tests are failing when attempting to navigate to a course, change class to whole header to click on to navigate to the next page.