### PR TITLE
update smoke test to new Find filter design

### DIFF
--- a/cypress/integration/find-teacher-training/basic.spec.ts
+++ b/cypress/integration/find-teacher-training/basic.spec.ts
@@ -42,7 +42,7 @@ describe("Basic", () => {
     cy.contains("Business studies").click();
     cy.contains("Continue").click();
     cy.get(".govuk-error-summary").should("not.exist");
-    cy.get("h1").should("contain", "Teacher training courses");
+    cy.get("[id=filter-line]").contains("Business studies courses in England");
   });
 
   it("should let users view a course", () => {

--- a/cypress/integration/find-teacher-training/geocoding.spec.ts
+++ b/cypress/integration/find-teacher-training/geocoding.spec.ts
@@ -29,7 +29,7 @@ describe("Geocoding", () => {
     cy.contains("Business studies").click();
     cy.contains("Continue").click();
     cy.get(".govuk-error-summary").should("not.exist");
-    cy.get("h1").should("contain", "Teacher training courses");
+    cy.get("[id=filter-line]").contains("Business studies courses in Westminster, London");
   });
 
   it("should let users view a course", () => {


### PR DESCRIPTION
We've update the Find design to move a couple of Filters to above the header. The text "Teacher training courses" no longer exists on the page